### PR TITLE
fix(plugins/better-calls): prevent crash in bot dm

### DIFF
--- a/plugins/better-calls/src/patches/silentCall.tsx
+++ b/plugins/better-calls/src/patches/silentCall.tsx
@@ -71,6 +71,7 @@ export const patch = (storage: PluginStorage, unpatches: UnpatchFunction[]) => {
             const fragmentProps = rt?.props?.children?.[0]?.props
 
             // This can occasionally be undefined because when you call someone, the call buttons are removed and replaced with the hang up button
+            // In bot DMs, it's an object.
             if (Array.isArray(fragmentProps?.children))
                 fragmentProps.children = [
                     <IconButton

--- a/plugins/better-calls/src/patches/silentCall.tsx
+++ b/plugins/better-calls/src/patches/silentCall.tsx
@@ -71,7 +71,7 @@ export const patch = (storage: PluginStorage, unpatches: UnpatchFunction[]) => {
             const fragmentProps = rt?.props?.children?.[0]?.props
 
             // This can occasionally be undefined because when you call someone, the call buttons are removed and replaced with the hang up button
-            if (fragmentProps?.children)
+            if (Array.isArray(fragmentProps?.children))
                 fragmentProps.children = [
                     <IconButton
                         key="better-calls:silent-call-toggle"


### PR DESCRIPTION
Closes #4

https://github.com/PalmDevs/revenge-plugins/blob/dc12213d803f09059cc55c96c239fa043bef20ff/plugins/better-calls/src/patches/silentCall.tsx#L71-L93

`fragmentProps.children` is usually an array that looks like this
```
[{"key":null,"ref":null,"props":{"size":"sm"}},[]]
```
but in bot dms it becomes an object
```
{"key":null,"ref":null,"props":{"size":"sm"}}
```
which leads to an error when trying to use the spread operator on it.

This PR just adds a check to ensure `fragmentProps.children` is an array